### PR TITLE
Release v0.1.0 - Initial npm publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, development]
   pull_request:
-    branches: [main]
+    branches: [main, development]
 
 jobs:
   test:
@@ -18,9 +18,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+        uses: pnpm/action-setup@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -43,32 +41,11 @@ jobs:
       - name: Build
         run: pnpm build
 
-  build:
-    runs-on: ubuntu-latest
-    needs: test
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
-
-      - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build
-        run: pnpm build
-
       - name: Verify dist
         run: |
           test -f dist/index.js
           test -f dist/index.cjs
           test -f dist/index.d.ts
+          test -f dist/chain/index.js
+          test -f dist/chain/index.cjs
+          test -f dist/chain/index.d.ts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,68 @@
+name: Publish to npm
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    # Only publish when package.json version has changed
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Type check
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+      - name: Check if version already published
+        id: version-check
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          echo "version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
+          echo "name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
+
+          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version 2>/dev/null; then
+            echo "published=true" >> $GITHUB_OUTPUT
+            echo "Version ${PACKAGE_VERSION} already published, skipping."
+          else
+            echo "published=false" >> $GITHUB_OUTPUT
+            echo "Version ${PACKAGE_VERSION} not yet published."
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm
+        if: steps.version-check.outputs.published == 'false'
+        run: pnpm publish --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Tag release
+        if: steps.version-check.outputs.published == 'false'
+        run: |
+          git tag "v${{ steps.version-check.outputs.version }}"
+          git push origin "v${{ steps.version-check.outputs.version }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,42 @@ pnpm lint           # ESLint
 pnpm format         # Prettier
 ```
 
+## Git Workflow & Releases
+
+### Branching
+
+- **`main`** — Protected. Requires 1 PR review, enforced for admins. No direct pushes.
+- **`development`** — Integration branch. All feature work merges here first.
+- **Feature branches** — Created from `development`: `feature/<name>`, `fix/<name>`, `chore/<name>`.
+
+### Flow
+
+1. Create feature branch from `development`
+2. Do work, commit, push, create PR to `development`
+3. Merge to `development` after CI passes
+4. When ready to release: bump version in `package.json`, create PR from `development` → `main`
+5. After merge to `main`, CI auto-publishes to npm and creates a git tag
+
+### Releasing to npm
+
+Publishing is automated via `.github/workflows/publish.yml`:
+- Triggers on push to `main`
+- Checks if `package.json` version is already published
+- If new version: runs tests, builds, publishes to npm, tags `vX.Y.Z`
+- If version unchanged: skips publish (safe for non-release merges)
+
+To release a new version:
+1. On `development`, bump version: edit `package.json` `"version"` field
+2. Commit: `chore: bump version to X.Y.Z`
+3. Create PR `development` → `main`
+4. After merge, npm publish happens automatically
+
+### CI
+
+- `.github/workflows/ci.yml` — Runs on all PRs and pushes to `main`/`development`
+- Matrix: Node 18.x + 20.x
+- Steps: typecheck → lint → test → build → verify dist
+
 ## Gateway URLs
 
 | Environment | URL |

--- a/package.json
+++ b/package.json
@@ -87,5 +87,6 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.3.3"
-  }
+  },
+  "packageManager": "pnpm@10.26.1"
 }


### PR DESCRIPTION
## Summary
- Add CI/CD pipeline with automated npm publishing
- Add MIT LICENSE file
- Add `packageManager` field for pnpm action v4
- Document git workflow and release process in CLAUDE.md

## What happens on merge
- Publish workflow will auto-publish `@datafund/swarm-provenance@0.1.0` to npm
- Git tag `v0.1.0` will be created

Closes #39