### PR TITLE
Add x402 payment support for paid gateway access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,8 @@ Features: upload text/files, download by reference, notary signing, metadata dis
 
 - `@noble/hashes` - SHA256 (same as Fairdrop v3)
 - `viem` - Optional peer dependency for blockchain anchoring (`./chain` entry point)
+- `@x402/fetch` - Optional peer dependency for x402 payment mode
+- `@x402/evm` - Optional peer dependency for x402 EVM payment signing
 
 ## Build Output
 
@@ -198,7 +200,34 @@ To release a new version:
 | Dev | `https://provenance-gateway.dev.datafund.io` |
 | Local | `http://localhost:8000` (swarm_connect) |
 
-Note: SDK adds `X-Payment-Mode: free` header by default for x402 compatibility.
+## Payment Modes (x402)
+
+The gateway supports the x402 payment protocol for paid access with higher rate limits.
+
+| Mode | Config | Behavior |
+|------|--------|----------|
+| Free (default) | `payment: 'free'` | Sends `X-Payment-Mode: free` header. Rate-limited (3 req/min). |
+| None | `payment: 'none'` | No payment header. Gets raw 402 responses. |
+| x402 paid | `payment: { wallet }` | Automatic USDC payments via `@x402/fetch`. No rate limits. |
+
+**Dependencies for x402 mode**: `@x402/fetch` and `@x402/evm` (optional peer deps, dynamically imported).
+
+**Setup**:
+```typescript
+import { createWalletClient, http, publicActions } from 'viem';
+import { baseSepolia } from 'viem/chains';
+import { privateKeyToAccount } from 'viem/accounts';
+
+const wallet = createWalletClient({
+  account: privateKeyToAccount('0x...'),
+  chain: baseSepolia,
+  transport: http(),
+}).extend(publicActions);
+
+const client = new ProvenanceClient({ payment: { wallet } });
+```
+
+The `PaymentWallet` interface requires `address`, `signTypedData`, and `readContract` — matching viem's `WalletClient.extend(publicActions)` or `@x402/evm`'s `toClientEvmSigner()`.
 
 ## Related Projects
 
@@ -222,6 +251,8 @@ Note: SDK adds `X-Payment-Mode: free` header by default for x402 compatibility.
 | `CHAIN_VALIDATION` | ChainValidationError | Bad hash format, invalid input |
 | `DATA_NOT_REGISTERED` | DataNotRegisteredError | Hash not found on-chain |
 | `SIGNER_REQUIRED` | SignerRequiredError | Write op without signer |
+| `PAYMENT_CONFIGURATION` | PaymentConfigurationError | Missing @x402 packages or invalid wallet |
+| `PAYMENT_RATE_LIMIT` | PaymentRateLimitError | 429 free tier limit exceeded |
 
 ## Blockchain Anchoring
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ For blockchain anchoring features, also install viem:
 pnpm add @datafund/swarm-provenance viem
 ```
 
+For x402 paid gateway access (higher rate limits), also install:
+
+```bash
+pnpm add @datafund/swarm-provenance @x402/fetch @x402/evm viem
+```
+
 ## Quick Start
 
 ```typescript
@@ -40,6 +46,37 @@ console.log('Uploaded:', result.reference);
 const downloaded = await client.download(result.reference);
 console.log('Content:', new TextDecoder().decode(downloaded.file));
 ```
+
+### x402 Payment Mode
+
+By default, the SDK uses the free tier (`X-Payment-Mode: free`), which is rate-limited. For higher throughput, configure x402 automatic USDC payments:
+
+```typescript
+import { ProvenanceClient } from '@datafund/swarm-provenance';
+import { createWalletClient, http } from 'viem';
+import { baseSepolia } from 'viem/chains';
+import { privateKeyToAccount } from 'viem/accounts';
+import { publicActions } from 'viem';
+
+// Create a signer with readContract support
+const wallet = createWalletClient({
+  account: privateKeyToAccount('0x...'),
+  chain: baseSepolia,
+  transport: http(),
+}).extend(publicActions);
+
+const client = new ProvenanceClient({
+  payment: { wallet },
+});
+
+// Requests that receive 402 responses are automatically paid via USDC
+const result = await client.upload('Hello, World!');
+```
+
+Payment modes:
+- `'free'` (default) — sends `X-Payment-Mode: free` header, rate-limited
+- `'none'` — no payment header, gets raw 402 responses
+- `{ wallet }` — automatic x402 USDC payments via `@x402/fetch`
 
 ### Blockchain Anchoring
 
@@ -79,8 +116,9 @@ await chain.anchor(contentHash, 'dataset');
 
 ```typescript
 const client = new ProvenanceClient({
-  gatewayUrl?: string,  // default: https://provenance-gateway.datafund.io
-  timeout?: number,     // default: 30000ms
+  gatewayUrl?: string,      // default: https://provenance-gateway.datafund.io
+  timeout?: number,         // default: 30000ms
+  payment?: PaymentMode,    // default: 'free' (see x402 Payment Mode)
 });
 ```
 
@@ -99,7 +137,6 @@ const result = await client.upload(content, {
 // {
 //   reference: string,           // Swarm hash
 //   metadata: ProvenanceMetadata,
-//   signedDocument?: SignedDocument,
 // }
 ```
 
@@ -147,12 +184,19 @@ import {
   StampError,
   NotaryError,
   VerificationError,
+  PaymentError,
+  PaymentConfigurationError,
+  PaymentRateLimitError,
 } from '@datafund/swarm-provenance';
 
 try {
   await client.upload(content);
 } catch (error) {
-  if (error instanceof StampError) {
+  if (error instanceof PaymentRateLimitError) {
+    console.error('Rate limited, retry after:', error.retryAfterSeconds, 'seconds');
+  } else if (error instanceof PaymentConfigurationError) {
+    console.error('Missing @x402 packages:', error.message);
+  } else if (error instanceof StampError) {
     console.error('Stamp acquisition failed:', error.message);
   } else if (error instanceof GatewayConnectionError) {
     console.error('Gateway error:', error.statusCode, error.message);

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "@types/node": "^20.11.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
+    "@x402/evm": "^2.5.0",
+    "@x402/fetch": "^2.5.0",
     "eslint": "^8.57.0",
     "prettier": "^3.2.0",
     "tsup": "^8.0.0",
@@ -78,10 +80,18 @@
     "vitest": "^1.2.0"
   },
   "peerDependencies": {
+    "@x402/evm": "^2.0.0",
+    "@x402/fetch": "^2.0.0",
     "viem": "^2.0.0"
   },
   "peerDependenciesMeta": {
     "viem": {
+      "optional": true
+    },
+    "@x402/fetch": {
+      "optional": true
+    },
+    "@x402/evm": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,12 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^7.0.0
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      '@x402/evm':
+        specifier: ^2.5.0
+        version: 2.5.0(ethers@6.16.0)(typescript@5.9.3)
+      '@x402/fetch':
+        specifier: ^2.5.0
+        version: 2.5.0(typescript@5.9.3)
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -35,12 +41,15 @@ importers:
         version: 5.9.3
       viem:
         specifier: ^2.46.3
-        version: 2.46.3(typescript@5.9.3)
+        version: 2.46.3(typescript@5.9.3)(zod@3.25.76)
       vitest:
         specifier: ^1.2.0
         version: 1.6.1(@types/node@20.19.30)
 
 packages:
+
+  '@adraffy/ens-normalize@1.10.1':
+    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
@@ -391,9 +400,16 @@ packages:
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/curves@1.2.0':
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+
   '@noble/curves@1.9.1':
     resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.3.2':
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -548,11 +564,29 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
+  '@spruceid/siwe-parser@2.1.2':
+    resolution: {integrity: sha512-d/r3S1LwJyMaRAKQ0awmo9whfXeE88Qt00vRj91q5uv5ATtWIQEGJ67Yr5eSZw5zp1/fZCXZYuEckt8lSkereQ==}
+
+  '@stablelib/binary@1.0.1':
+    resolution: {integrity: sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==}
+
+  '@stablelib/int@1.0.1':
+    resolution: {integrity: sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==}
+
+  '@stablelib/random@1.0.2':
+    resolution: {integrity: sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==}
+
+  '@stablelib/wipe@1.0.1':
+    resolution: {integrity: sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/node@20.19.30':
     resolution: {integrity: sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==}
+
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
   '@typescript-eslint/eslint-plugin@7.18.0':
     resolution: {integrity: sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==}
@@ -630,6 +664,18 @@ packages:
   '@vitest/utils@1.6.1':
     resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
 
+  '@x402/core@2.5.0':
+    resolution: {integrity: sha512-nUr8HW8WhkU1DvrpUfsRvALy5NF8UWKoFezZOtX61mohxp2lWZpJ2GnvscxDM8nmBAbtIollmksd5z5pj8InXw==}
+
+  '@x402/evm@2.5.0':
+    resolution: {integrity: sha512-MBSTQZwLobMVcmYO7itOMJRkxfHstsDyr7F94o9Rk/Oinz0kjvCe4DFgZmFXyz3nQUgQFmDVgTK5KIzfYR5uIA==}
+
+  '@x402/extensions@2.5.0':
+    resolution: {integrity: sha512-e7IQShbGUM/XQmzI8DQh2tX/k2XDUGI9DNF+ij2NHUyPEqAt5/mJCwOlaxS/60FWFdfFRfWjTsqaoS7Z8WLi+A==}
+
+  '@x402/fetch@2.5.0':
+    resolution: {integrity: sha512-D2jH3bn0nf8w9Jg3Vxo+6reE6Z9GickzkSIw+udITJFvsrGOpfjZvhcTeflLcthCODk4Nuu9Oe8x7Q3NLUdaRQ==}
+
   abitype@1.2.3:
     resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
     peerDependencies:
@@ -655,8 +701,14 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  aes-js@4.0.0-beta.5:
+    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -672,6 +724,9 @@ packages:
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  apg-js@4.4.0:
+    resolution: {integrity: sha512-fefmXFknJmtgtNEXfPwZKYkMFX4Fyeyz+fNF6JWp87biGOPslJbCBVU158zvKRZfHBKnJDy8CMM40oLFGkXT8Q==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -829,6 +884,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  ethers@6.16.0:
+    resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
+    engines: {node: '>=14.0.0'}
+
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
@@ -848,6 +907,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -992,6 +1054,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1209,6 +1274,10 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -1253,6 +1322,11 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  siwe@2.3.2:
+    resolution: {integrity: sha512-aSf+6+Latyttbj5nMu6GF3doMfv2UYj83hhwZgUF20ky6fTS83uVhkQABdIVnEuS8y1bBdk7p6ltb9SmlhTTlA==}
+    peerDependencies:
+      ethers: ^5.6.8 || ^6.0.8
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -1341,6 +1415,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
   tsup@8.5.1:
     resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
     engines: {node: '>=18'}
@@ -1359,6 +1436,9 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -1380,11 +1460,17 @@ packages:
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  valid-url@1.0.9:
+    resolution: {integrity: sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==}
 
   viem@2.46.3:
     resolution: {integrity: sha512-2LJS+Hyh2sYjHXQtzfv1kU9pZx9dxFzvoU/ZKIcn0FNtOU0HQuIICuYdWtUDFHaGXbAdVo8J1eCvmjkL9JVGwg==}
@@ -1472,6 +1558,18 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.17.1:
+    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
     engines: {node: '>=10.0.0'}
@@ -1492,7 +1590,12 @@ packages:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
+
+  '@adraffy/ens-normalize@1.10.1': {}
 
   '@adraffy/ens-normalize@1.11.1': {}
 
@@ -1698,9 +1801,15 @@ snapshots:
 
   '@noble/ciphers@1.3.0': {}
 
+  '@noble/curves@1.2.0':
+    dependencies:
+      '@noble/hashes': 1.3.2
+
   '@noble/curves@1.9.1':
     dependencies:
       '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.8.0': {}
 
@@ -1806,11 +1915,35 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
+  '@spruceid/siwe-parser@2.1.2':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      apg-js: 4.4.0
+      uri-js: 4.4.1
+      valid-url: 1.0.9
+
+  '@stablelib/binary@1.0.1':
+    dependencies:
+      '@stablelib/int': 1.0.1
+
+  '@stablelib/int@1.0.1': {}
+
+  '@stablelib/random@1.0.2':
+    dependencies:
+      '@stablelib/binary': 1.0.1
+      '@stablelib/wipe': 1.0.1
+
+  '@stablelib/wipe@1.0.1': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/node@20.19.30':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/node@22.7.5':
+    dependencies:
+      undici-types: 6.19.8
 
   '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -1924,9 +2057,51 @@ snapshots:
       loupe: 2.3.7
       pretty-format: 29.7.0
 
-  abitype@1.2.3(typescript@5.9.3):
+  '@x402/core@2.5.0':
+    dependencies:
+      zod: 3.25.76
+
+  '@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3)':
+    dependencies:
+      '@x402/core': 2.5.0
+      '@x402/extensions': 2.5.0(ethers@6.16.0)(typescript@5.9.3)
+      viem: 2.46.3(typescript@5.9.3)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - ethers
+      - typescript
+      - utf-8-validate
+
+  '@x402/extensions@2.5.0(ethers@6.16.0)(typescript@5.9.3)':
+    dependencies:
+      '@scure/base': 1.2.6
+      '@x402/core': 2.5.0
+      ajv: 8.18.0
+      siwe: 2.3.2(ethers@6.16.0)
+      tweetnacl: 1.0.3
+      viem: 2.46.3(typescript@5.9.3)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - ethers
+      - typescript
+      - utf-8-validate
+
+  '@x402/fetch@2.5.0(typescript@5.9.3)':
+    dependencies:
+      '@x402/core': 2.5.0
+      viem: 2.46.3(typescript@5.9.3)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  abitype@1.2.3(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:
       typescript: 5.9.3
+      zod: 3.25.76
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -1938,12 +2113,21 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  aes-js@4.0.0-beta.5: {}
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -1954,6 +2138,8 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   any-promise@1.3.0: {}
+
+  apg-js@4.4.0: {}
 
   argparse@2.0.1: {}
 
@@ -2177,6 +2363,19 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  ethers@6.16.0:
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.17.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   eventemitter3@5.0.1: {}
 
   execa@8.0.1:
@@ -2204,6 +2403,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-uri@3.1.0: {}
 
   fastq@1.20.1:
     dependencies:
@@ -2331,6 +2532,8 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
+  json-schema-traverse@1.0.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   keyv@4.5.4:
@@ -2428,7 +2631,7 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  ox@0.12.4(typescript@5.9.3):
+  ox@0.12.4(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -2436,7 +2639,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -2519,6 +2722,8 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
@@ -2575,6 +2780,14 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  siwe@2.3.2(ethers@6.16.0):
+    dependencies:
+      '@spruceid/siwe-parser': 2.1.2
+      '@stablelib/random': 1.0.2
+      ethers: 6.16.0
+      uri-js: 4.4.1
+      valid-url: 1.0.9
 
   slash@3.0.0: {}
 
@@ -2647,6 +2860,8 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  tslib@2.7.0: {}
+
   tsup@8.5.1(postcss@8.5.6)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.2)
@@ -2675,6 +2890,8 @@ snapshots:
       - tsx
       - yaml
 
+  tweetnacl@1.0.3: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -2687,21 +2904,25 @@ snapshots:
 
   ufo@1.6.3: {}
 
+  undici-types@6.19.8: {}
+
   undici-types@6.21.0: {}
 
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
-  viem@2.46.3(typescript@5.9.3):
+  valid-url@1.0.9: {}
+
+  viem@2.46.3(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
       isows: 1.0.7(ws@8.18.3)
-      ox: 0.12.4(typescript@5.9.3)
+      ox: 0.12.4(typescript@5.9.3)(zod@3.25.76)
       ws: 8.18.3
     optionalDependencies:
       typescript: 5.9.3
@@ -2784,8 +3005,12 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  ws@8.17.1: {}
+
   ws@8.18.3: {}
 
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
+
+  zod@3.25.76: {}

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,7 @@
 import type {
   ProvenanceClientConfig,
+  PaymentMode,
+  X402PaymentConfig,
   UploadOptions,
   DownloadOptions,
   UploadResult,
@@ -20,10 +22,12 @@ import {
   GatewayConnectionError,
   StampError,
   NotaryError,
+  PaymentRateLimitError,
 } from './errors.js';
 import { buildMetadata, extractContent, verifyContentHash } from './metadata.js';
 import { verifyAllSignatures } from './notary.js';
 import { toBytes } from './utils.js';
+import { createX402Fetch } from './payment.js';
 
 const DEFAULT_GATEWAY_URL = 'https://provenance-gateway.datafund.io';
 const DEFAULT_TIMEOUT = 30000;
@@ -34,10 +38,32 @@ const DEFAULT_TIMEOUT = 30000;
 export class ProvenanceClient {
   private readonly gatewayUrl: string;
   private readonly timeout: number;
+  private readonly paymentMode: PaymentMode;
+  private x402Fetch: typeof fetch | undefined;
+  private x402FetchPromise: Promise<typeof fetch> | undefined;
 
   constructor(config: ProvenanceClientConfig = {}) {
     this.gatewayUrl = (config.gatewayUrl ?? DEFAULT_GATEWAY_URL).replace(/\/$/, '');
     this.timeout = config.timeout ?? DEFAULT_TIMEOUT;
+    this.paymentMode = config.payment ?? 'free';
+  }
+
+  /**
+   * Get or create the x402-wrapped fetch (lazy singleton with dedup)
+   */
+  private getX402Fetch(): Promise<typeof fetch> {
+    if (this.x402Fetch) {
+      return Promise.resolve(this.x402Fetch);
+    }
+    if (!this.x402FetchPromise) {
+      this.x402FetchPromise = createX402Fetch(this.paymentMode as X402PaymentConfig).then(
+        (wrappedFetch) => {
+          this.x402Fetch = wrappedFetch;
+          return wrappedFetch;
+        }
+      );
+    }
+    return this.x402FetchPromise;
   }
 
   /**
@@ -275,20 +301,51 @@ export class ProvenanceClient {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), this.timeout);
 
-    // Merge headers, adding X-Payment-Mode: free for x402 compatibility
     const headers = new Headers(init?.headers);
-    if (!headers.has('X-Payment-Mode')) {
-      headers.set('X-Payment-Mode', 'free');
+    const isX402 = typeof this.paymentMode === 'object';
+
+    // Set payment header based on mode
+    if (this.paymentMode === 'free') {
+      if (!headers.has('X-Payment-Mode')) {
+        headers.set('X-Payment-Mode', 'free');
+      }
+    }
+    // 'none' and x402: no X-Payment-Mode header
+
+    // Choose fetch implementation
+    let fetchFn: typeof fetch;
+    if (isX402) {
+      fetchFn = await this.getX402Fetch();
+    } else {
+      fetchFn = fetch;
     }
 
     try {
-      const response = await fetch(url, {
+      const response = await fetchFn(url, {
         ...init,
         headers,
         signal: controller.signal,
       });
+
+      // Detect free-tier rate limiting
+      if (response.status === 429 && this.paymentMode === 'free') {
+        const retryAfter = response.headers.get('Retry-After');
+        const rateLimit = response.headers.get('X-RateLimit-Limit');
+        const rateRemaining = response.headers.get('X-RateLimit-Remaining');
+
+        throw new PaymentRateLimitError(
+          'Free tier rate limit exceeded. Consider using x402 payment mode for higher limits.',
+          retryAfter ? parseInt(retryAfter, 10) : undefined,
+          rateLimit ? parseInt(rateLimit, 10) : undefined,
+          rateRemaining ? parseInt(rateRemaining, 10) : undefined
+        );
+      }
+
       return response;
     } catch (error) {
+      if (error instanceof PaymentRateLimitError) {
+        throw error;
+      }
       if (error instanceof Error && error.name === 'AbortError') {
         throw new GatewayConnectionError('Request timed out', undefined, 'TIMEOUT');
       }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -59,3 +59,41 @@ export class VerificationError extends ProvenanceError {
     Object.setPrototypeOf(this, VerificationError.prototype);
   }
 }
+
+/**
+ * Base error for payment-related issues
+ */
+export class PaymentError extends ProvenanceError {
+  constructor(message: string, code?: string) {
+    super(message, code);
+    this.name = 'PaymentError';
+    Object.setPrototypeOf(this, PaymentError.prototype);
+  }
+}
+
+/**
+ * Error when x402 payment packages are missing or wallet is invalid
+ */
+export class PaymentConfigurationError extends PaymentError {
+  constructor(message: string) {
+    super(message, 'PAYMENT_CONFIGURATION');
+    this.name = 'PaymentConfigurationError';
+    Object.setPrototypeOf(this, PaymentConfigurationError.prototype);
+  }
+}
+
+/**
+ * Error when free tier rate limit (429) is exceeded
+ */
+export class PaymentRateLimitError extends PaymentError {
+  constructor(
+    message: string,
+    public readonly retryAfterSeconds?: number,
+    public readonly requestsLimit?: number,
+    public readonly requestsRemaining?: number
+  ) {
+    super(message, 'PAYMENT_RATE_LIMIT');
+    this.name = 'PaymentRateLimitError';
+    Object.setPrototypeOf(this, PaymentRateLimitError.prototype);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,9 @@ export { ProvenanceClient } from './client.js';
 // Types
 export type {
   ProvenanceClientConfig,
+  PaymentWallet,
+  X402PaymentConfig,
+  PaymentMode,
   UploadOptions,
   DownloadOptions,
   UploadResult,
@@ -23,6 +26,9 @@ export {
   StampError,
   NotaryError,
   VerificationError,
+  PaymentError,
+  PaymentConfigurationError,
+  PaymentRateLimitError,
 } from './errors.js';
 
 // Utilities (for advanced use)

--- a/src/payment.ts
+++ b/src/payment.ts
@@ -1,0 +1,36 @@
+import type { X402PaymentConfig } from './types.js';
+import { PaymentConfigurationError } from './errors.js';
+
+/**
+ * Create an x402-wrapped fetch function that automatically handles 402 payment responses.
+ *
+ * Dynamically imports @x402/fetch and @x402/evm — throws PaymentConfigurationError
+ * if they are not installed.
+ */
+export async function createX402Fetch(config: X402PaymentConfig): Promise<typeof fetch> {
+  let x402Fetch: typeof import('@x402/fetch');
+  let x402Evm: typeof import('@x402/evm');
+
+  try {
+    x402Fetch = await import('@x402/fetch');
+  } catch {
+    throw new PaymentConfigurationError(
+      '@x402/fetch is required for x402 payment mode. Install it: pnpm add @x402/fetch'
+    );
+  }
+
+  try {
+    x402Evm = await import('@x402/evm');
+  } catch {
+    throw new PaymentConfigurationError(
+      '@x402/evm is required for x402 payment mode. Install it: pnpm add @x402/evm'
+    );
+  }
+
+  const network = config.network ?? 'eip155:84532';
+  const client = new x402Fetch.x402Client();
+  const scheme = new x402Evm.ExactEvmScheme(config.wallet);
+  client.register(network, scheme);
+
+  return x402Fetch.wrapFetchWithPayment(fetch, client);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,43 @@
 /**
+ * Wallet interface for x402 payment signing.
+ * Compatible with viem's WalletClient extended with publicActions, or
+ * composed via `toClientEvmSigner(account, publicClient)` from @x402/evm.
+ */
+export interface PaymentWallet {
+  address: `0x${string}`;
+  signTypedData(args: {
+    domain: Record<string, unknown>;
+    types: Record<string, unknown>;
+    primaryType: string;
+    message: Record<string, unknown>;
+  }): Promise<`0x${string}`>;
+  readContract(args: {
+    address: `0x${string}`;
+    abi: readonly unknown[];
+    functionName: string;
+    args?: readonly unknown[];
+  }): Promise<unknown>;
+}
+
+/**
+ * Configuration for x402 automatic payment mode
+ */
+export interface X402PaymentConfig {
+  /** Wallet that signs x402 payment authorizations */
+  wallet: PaymentWallet;
+  /** CAIP-2 network identifier (default: 'eip155:84532' for Base Sepolia) */
+  network?: `${string}:${string}`;
+}
+
+/**
+ * Payment mode for gateway access.
+ * - 'free': Sends X-Payment-Mode: free header (default, rate-limited)
+ * - 'none': No payment header (get raw 402 responses)
+ * - X402PaymentConfig: Automatic x402 USDC payments
+ */
+export type PaymentMode = 'free' | 'none' | X402PaymentConfig;
+
+/**
  * Configuration options for ProvenanceClient
  */
 export interface ProvenanceClientConfig {
@@ -6,6 +45,8 @@ export interface ProvenanceClientConfig {
   gatewayUrl?: string;
   /** Request timeout in milliseconds (default: 30000) */
   timeout?: number;
+  /** Payment mode for gateway access (default: 'free') */
+  payment?: PaymentMode;
 }
 
 /**

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ProvenanceClient } from '../../src/client.js';
-import { GatewayConnectionError, StampError, NotaryError } from '../../src/errors.js';
+import { GatewayConnectionError, StampError, NotaryError, PaymentRateLimitError } from '../../src/errors.js';
 
 // Mock fetch globally
 const mockFetch = vi.fn();
@@ -400,6 +400,111 @@ describe('ProvenanceClient', () => {
 
       // health() catches errors and returns false
       await expect(client.health()).resolves.toBe(false);
+    });
+  });
+
+  describe('payment modes', () => {
+    function getRequestHeaders(): Headers {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      return mockFetch.mock.calls[0][1].headers as Headers;
+    }
+
+    it('should send X-Payment-Mode: free header by default', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true });
+
+      const client = new ProvenanceClient();
+      await client.health();
+
+      expect(getRequestHeaders().get('X-Payment-Mode')).toBe('free');
+    });
+
+    it('should send X-Payment-Mode: free header when payment is "free"', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true });
+
+      const client = new ProvenanceClient({ payment: 'free' });
+      await client.health();
+
+      expect(getRequestHeaders().get('X-Payment-Mode')).toBe('free');
+    });
+
+    it('should not send X-Payment-Mode header when payment is "none"', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true });
+
+      const client = new ProvenanceClient({ payment: 'none' });
+      await client.health();
+
+      expect(getRequestHeaders().has('X-Payment-Mode')).toBe(false);
+    });
+
+    it('should accept x402 config in constructor without error', () => {
+      const mockWallet = {
+        address: '0x1234567890abcdef1234567890abcdef12345678' as `0x${string}`,
+        signTypedData: vi.fn(),
+        readContract: vi.fn(),
+      };
+      const client = new ProvenanceClient({
+        payment: { wallet: mockWallet },
+      });
+      expect(client).toBeInstanceOf(ProvenanceClient);
+    });
+
+    it('should throw PaymentRateLimitError on 429 in free mode', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+        headers: new Headers({
+          'Retry-After': '60',
+          'X-RateLimit-Limit': '3',
+          'X-RateLimit-Remaining': '0',
+        }),
+      });
+
+      const client = new ProvenanceClient();
+      await expect(client.health()).resolves.toBe(false);
+    });
+
+    it('should include retry metadata in PaymentRateLimitError', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+        headers: new Headers({
+          'Retry-After': '60',
+          'X-RateLimit-Limit': '3',
+          'X-RateLimit-Remaining': '0',
+        }),
+      });
+
+      const client = new ProvenanceClient();
+
+      // Use notaryInfo() which doesn't swallow errors like health()
+      try {
+        await client.notaryInfo();
+        expect.fail('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(PaymentRateLimitError);
+        const rateError = error as PaymentRateLimitError;
+        expect(rateError.retryAfterSeconds).toBe(60);
+        expect(rateError.requestsLimit).toBe(3);
+        expect(rateError.requestsRemaining).toBe(0);
+        expect(rateError.code).toBe('PAYMENT_RATE_LIMIT');
+      }
+    });
+
+    it('should not throw PaymentRateLimitError on 429 when payment is "none"', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+        headers: new Headers({}),
+        json: () => Promise.resolve({ detail: 'Rate limited' }),
+      });
+
+      const client = new ProvenanceClient({ payment: 'none' });
+      // Should throw regular GatewayConnectionError, not PaymentRateLimitError
+      await expect(client.notaryInfo()).rejects.toThrow(GatewayConnectionError);
+      await expect(client.notaryInfo()).rejects.not.toThrow(PaymentRateLimitError);
     });
   });
 });

--- a/tests/unit/payment.test.ts
+++ b/tests/unit/payment.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('createX402Fetch', () => {
+  const mockWallet = {
+    address: '0x1234567890abcdef1234567890abcdef12345678' as `0x${string}`,
+    signTypedData: vi.fn().mockResolvedValue('0xsig' as `0x${string}`),
+    readContract: vi.fn().mockResolvedValue(0n),
+  };
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('should throw PaymentConfigurationError when @x402/fetch is missing', async () => {
+    vi.doMock('@x402/fetch', () => {
+      throw new Error('Cannot find module');
+    });
+
+    const { createX402Fetch } = await import('../../src/payment.js');
+
+    try {
+      await createX402Fetch({ wallet: mockWallet });
+      expect.fail('Should have thrown');
+    } catch (error) {
+      expect((error as Error).name).toBe('PaymentConfigurationError');
+      expect((error as Error).message).toContain('@x402/fetch is required');
+    }
+  });
+
+  it('should throw PaymentConfigurationError when @x402/evm is missing', async () => {
+    vi.doMock('@x402/fetch', () => ({
+      x402Client: class {
+        register() { return this; }
+      },
+      wrapFetchWithPayment: vi.fn(),
+    }));
+    vi.doMock('@x402/evm', () => {
+      throw new Error('Cannot find module');
+    });
+
+    const { createX402Fetch } = await import('../../src/payment.js');
+
+    try {
+      await createX402Fetch({ wallet: mockWallet });
+      expect.fail('Should have thrown');
+    } catch (error) {
+      expect((error as Error).name).toBe('PaymentConfigurationError');
+      expect((error as Error).message).toContain('@x402/evm is required');
+    }
+  });
+
+  it('should create wrapped fetch when both packages are available', async () => {
+    const mockWrappedFetch = vi.fn();
+    const mockRegister = vi.fn().mockReturnThis();
+
+    vi.doMock('@x402/fetch', () => ({
+      x402Client: class {
+        register = mockRegister;
+      },
+      wrapFetchWithPayment: vi.fn().mockReturnValue(mockWrappedFetch),
+    }));
+    vi.doMock('@x402/evm', () => ({
+      ExactEvmScheme: class {
+        constructor(public signer: unknown) {}
+      },
+    }));
+
+    const { createX402Fetch } = await import('../../src/payment.js');
+    const result = await createX402Fetch({ wallet: mockWallet });
+
+    expect(result).toBe(mockWrappedFetch);
+    expect(mockRegister).toHaveBeenCalledWith('eip155:84532', expect.any(Object));
+  });
+
+  it('should use custom network when provided', async () => {
+    const mockRegister = vi.fn().mockReturnThis();
+
+    vi.doMock('@x402/fetch', () => ({
+      x402Client: class {
+        register = mockRegister;
+      },
+      wrapFetchWithPayment: vi.fn().mockReturnValue(vi.fn()),
+    }));
+    vi.doMock('@x402/evm', () => ({
+      ExactEvmScheme: class {
+        constructor(public signer: unknown) {}
+      },
+    }));
+
+    const { createX402Fetch } = await import('../../src/payment.js');
+    await createX402Fetch({ wallet: mockWallet, network: 'eip155:8453' });
+
+    expect(mockRegister).toHaveBeenCalledWith('eip155:8453', expect.any(Object));
+  });
+
+  it('should pass wallet to ExactEvmScheme constructor', async () => {
+    let capturedSigner: unknown;
+
+    vi.doMock('@x402/fetch', () => ({
+      x402Client: class {
+        register() { return this; }
+      },
+      wrapFetchWithPayment: vi.fn().mockReturnValue(vi.fn()),
+    }));
+    vi.doMock('@x402/evm', () => ({
+      ExactEvmScheme: class {
+        constructor(signer: unknown) {
+          capturedSigner = signer;
+        }
+      },
+    }));
+
+    const { createX402Fetch } = await import('../../src/payment.js');
+    await createX402Fetch({ wallet: mockWallet });
+
+    expect(capturedSigner).toBe(mockWallet);
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -11,5 +11,5 @@ export default defineConfig({
   minify: false,
   target: 'es2022',
   outDir: 'dist',
-  external: ['viem'],
+  external: ['viem', '@x402/fetch', '@x402/evm', '@x402/evm/exact/client'],
 });


### PR DESCRIPTION
## Summary

- Add configurable payment modes to `ProvenanceClient`: `'free'` (default), `'none'`, and x402 automatic USDC payments
- Add `PaymentWallet` interface, `PaymentRateLimitError` for 429 handling, and lazy x402 fetch wrapper with dynamic imports
- `@x402/fetch` and `@x402/evm` added as optional peer dependencies, dynamically imported only when x402 mode is configured

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 179 tests pass (12 new: 5 payment module + 7 client payment modes)
- [x] `pnpm build` — builds with @x402 packages properly externalized
- [ ] CI matrix (Node 18.x + 20.x) passes

Closes #53, closes #54, closes #55, closes #56, closes #57